### PR TITLE
fix-south-dakota

### DIFF
--- a/app/views/prototype-1/check-eligibility/country-usa.html
+++ b/app/views/prototype-1/check-eligibility/country-usa.html
@@ -45,7 +45,7 @@ In which state/territory are you currently recognised as a teacher? – {{ servi
     "Pennsylvania",
     "Rhode Island",
     "South Carolina",
-    "South Dakota"
+    "South Dakota",
     "Tennessee",
     "Texas",
     "Utah",


### PR DESCRIPTION
fix for a bug introduced by my last commit.
Comma lost from south dakota after alphabetising