### PR TITLE
Specify Python version

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
 nodejs 16.13.0
+python 3.10.5


### PR DESCRIPTION
The node-gym library depends on Python being installed, so we should specify a version to install so users only have to run `asdf install` to get everything they need.

https://github.com/nodejs/node-gyp#on-unix