### PR TITLE
Changed ‘Who you can teach’ nesting

### DIFF
--- a/app/views/prototype-3/task-list.html
+++ b/app/views/prototype-3/task-list.html
@@ -115,13 +115,6 @@
               <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="undergraduate-degree-documents-status">Cannot start yet</strong>
             </li>
             {% endif %}
-          </ul>
-        </li>
-        <li>
-          <h2 class="app-task-list__section">
-            Who you can teach
-          </h2>
-          <ul class="app-task-list__items">
             <li class="app-task-list__item">
               <span class="app-task-list__task-name">
                 <a href="who-you-can-teach/age-range" aria-describedby="age-range">


### PR DESCRIPTION
Moved the ‘Who you can teach’ section to sit within “Your qualifications” after team meeting.

Signed-off-by: Andrew Scrivener <andrew.scrivener@digital.homeoffice.gov.uk>