### PR TITLE
Various copy changes following latest user test

### DIFF
--- a/app/views/prototype-3/qualifications/teacher-training-qualification-documents/upload-teacher-training-qualification-2.html
+++ b/app/views/prototype-3/qualifications/teacher-training-qualification-documents/upload-teacher-training-qualification-2.html
@@ -17,7 +17,7 @@
         <span class="govuk-caption-l">
           Your qualifications
         </span>
-        <h1 class="govuk-heading-l">Upload your {{ data['qualificationInstitutionName'] }} teacher training qualification</h1>
+        <h1 class="govuk-heading-l">Upload your {{ data['qualificationInstitutionName'] }} teaching qualification certificate</h1>
         <div class="govuk-form-group">
           <label class="govuk-label" for="file-upload-1">
             Select a file to upload
@@ -56,7 +56,7 @@
               <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-written-in-english-2">
                 <div class="govuk-form-group">
                   <label class="govuk-label" for="file-upload-2">
-                    Upload your degree certificate translation
+                    Upload your teaching qualification certificate translation
                   </label>
                   <div id="event-name-hint" class="govuk-hint">
                     Select a file to upload

--- a/app/views/prototype-3/qualifications/teacher-training-qualification-documents/upload-teacher-training-qualification-3.html
+++ b/app/views/prototype-3/qualifications/teacher-training-qualification-documents/upload-teacher-training-qualification-3.html
@@ -17,7 +17,7 @@
         <span class="govuk-caption-l">
           Your qualifications
         </span>
-        <h1 class="govuk-heading-l">Upload your {{ data['qualificationInstitutionName'] }} teacher training qualification</h1>
+        <h1 class="govuk-heading-l">Upload your {{ data['qualificationInstitutionName'] }} teaching qualification certificate</h1>
         <div class="govuk-form-group">
           <label class="govuk-label" for="file-upload-1">
             Select a file to upload
@@ -56,7 +56,7 @@
               <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-written-in-english-2">
                 <div class="govuk-form-group">
                   <label class="govuk-label" for="file-upload-2">
-                    Upload your degree certificate translation
+                    Upload your teaching qualification certificate translation
                   </label>
                   <div id="event-name-hint" class="govuk-hint">
                     Select a file to upload

--- a/app/views/prototype-3/qualifications/teacher-training-qualification-documents/upload-teacher-training-qualification-error.html
+++ b/app/views/prototype-3/qualifications/teacher-training-qualification-documents/upload-teacher-training-qualification-error.html
@@ -17,7 +17,7 @@
         <span class="govuk-caption-l">
           Your qualifications
         </span>
-        <h1 class="govuk-heading-l">Upload your {{ data['qualificationInstitutionName'] }} teacher training qualification</h1>
+        <h1 class="govuk-heading-l">Upload your {{ data['qualificationInstitutionName'] }} teaching qualification certificate</h1>
 
         <div class="govuk-form-group govuk-form-group--error">
           <label class="govuk-label" for="file-upload-1">
@@ -60,7 +60,7 @@
               <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-written-in-english-2">
                 <div class="govuk-form-group">
                   <label class="govuk-label" for="file-upload-2">
-                    Upload your degree certificate translation
+                    Upload your teaching qualification certificate translation
                   </label>
                   <div id="event-name-hint" class="govuk-hint">
                     Select a file to upload

--- a/app/views/prototype-3/qualifications/teacher-training-qualification-documents/upload-teacher-training-qualification.html
+++ b/app/views/prototype-3/qualifications/teacher-training-qualification-documents/upload-teacher-training-qualification.html
@@ -17,7 +17,7 @@
         <span class="govuk-caption-l">
           Your qualifications
         </span>
-        <h1 class="govuk-heading-l">Upload your {{ data['qualificationInstitutionName'] }} teacher training qualification</h1>
+        <h1 class="govuk-heading-l">Upload your {{ data['qualificationInstitutionName'] }} teaching qualification certificate</h1>
         <div class="govuk-form-group">
           <label class="govuk-label" for="file-upload-1">
             Select a file to upload
@@ -56,7 +56,7 @@
               <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-written-in-english-2">
                 <div class="govuk-form-group">
                   <label class="govuk-label" for="file-upload-2">
-                    Upload your degree certificate translation
+                    Upload your teaching qualification certificate translation
                   </label>
                   <div id="event-name-hint" class="govuk-hint">
                     Select a file to upload

--- a/app/views/prototype-3/qualifications/teacher-training-qualification-documents/upload-teacher-training-transcript-2.html
+++ b/app/views/prototype-3/qualifications/teacher-training-qualification-documents/upload-teacher-training-transcript-2.html
@@ -17,8 +17,9 @@
         <span class="govuk-caption-l">
           Your qualifications
         </span>
-        <h1 class="govuk-heading-l">Upload your {{ data['qualificationInstitutionName'] }} teacher training transcript</h1>
-        <p>Upload a transcript of your teacher training qualification, issued by the awarding body. If your teacher training was completed as part of your degree, you should supply your degree transcript.</p>
+        <h1 class="govuk-heading-l">Upload your {{ data['qualificationInstitutionName'] }} teaching qualification transcript
+</h1>
+        <p>Upload a transcript of your teaching qualification, issued by the awarding body. If your teaching qualification was completed as part of your degree, you should supply your degree transcript.</p>
         <h2 class="govuk-heading-m">Upload your transcript</h2>
         <div class="govuk-form-group">
           <label class="govuk-label" for="file-upload-1">
@@ -68,7 +69,7 @@
               <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-written-in-english-2">
                 <div class="govuk-form-group">
                   <label class="govuk-label" for="file-upload-2">
-                    Upload your qualification certificate translation
+                    Upload your teaching qualification transcript translation
                   </label>
                   <div id="event-name-hint" class="govuk-hint">
                     Select a file to upload

--- a/app/views/prototype-3/qualifications/teacher-training-qualification-documents/upload-teacher-training-transcript-3.html
+++ b/app/views/prototype-3/qualifications/teacher-training-qualification-documents/upload-teacher-training-transcript-3.html
@@ -17,8 +17,9 @@
         <span class="govuk-caption-l">
           Your qualifications
         </span>
-        <h1 class="govuk-heading-l">Upload your {{ data['qualificationInstitutionName'] }} teacher training transcript</h1>
-        <p>Upload a transcript of your teacher training qualification, issued by the awarding body. If your teacher training was completed as part of your degree, you should supply your degree transcript.</p>
+        <h1 class="govuk-heading-l">Upload your {{ data['qualificationInstitutionName'] }} teaching qualification transcript
+</h1>
+        <p>Upload a transcript of your teaching qualification, issued by the awarding body. If your teaching qualification was completed as part of your degree, you should supply your degree transcript.</p>
         <h2 class="govuk-heading-m">Upload your transcript</h2>
         <div class="govuk-form-group">
           <label class="govuk-label" for="file-upload-1">
@@ -68,7 +69,7 @@
               <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-written-in-english-2">
                 <div class="govuk-form-group">
                   <label class="govuk-label" for="file-upload-2">
-                    Upload your qualification certificate translation
+                    Upload your teaching qualification transcript translation
                   </label>
                   <div id="event-name-hint" class="govuk-hint">
                     Select a file to upload

--- a/app/views/prototype-3/qualifications/teacher-training-qualification-documents/upload-teacher-training-transcript-error.html
+++ b/app/views/prototype-3/qualifications/teacher-training-qualification-documents/upload-teacher-training-transcript-error.html
@@ -17,8 +17,9 @@
         <span class="govuk-caption-l">
           Your qualifications
         </span>
-        <h1 class="govuk-heading-l">Upload your {{ data['qualificationInstitutionName'] }} teacher training transcript</h1>
-        <p>Upload a transcript of your teacher training qualification, issued by the awarding body. If your teacher training was completed as part of your degree, you should supply your degree transcript.</p>
+        <h1 class="govuk-heading-l">Upload your {{ data['qualificationInstitutionName'] }} teaching qualification transcript
+</h1>
+        <p>Upload a transcript of your teaching qualification, issued by the awarding body. If your teaching qualification was completed as part of your degree, you should supply your degree transcript.</p>
         <h2 class="govuk-heading-m">Upload your transcript</h2>
         <div class="govuk-form-group govuk-form-group--error">
           <label class="govuk-label" for="file-upload-1">
@@ -71,7 +72,7 @@
               <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-written-in-english-2">
                 <div class="govuk-form-group">
                   <label class="govuk-label" for="file-upload-2">
-                    Upload your qualification certificate translation
+                    Upload your teaching qualification transcript translation
                   </label>
                   <div id="event-name-hint" class="govuk-hint">
                     Select a file to upload

--- a/app/views/prototype-3/qualifications/teacher-training-qualification-documents/upload-teacher-training-transcript.html
+++ b/app/views/prototype-3/qualifications/teacher-training-qualification-documents/upload-teacher-training-transcript.html
@@ -17,8 +17,8 @@
         <span class="govuk-caption-l">
           Your qualifications
         </span>
-        <h1 class="govuk-heading-l">Upload your {{ data['qualificationInstitutionName'] }} teacher training transcript</h1>
-        <p>Upload a transcript of your teacher training qualification, issued by the awarding body. If your teacher training was completed as part of your degree, you should supply your degree transcript.</p>
+        <h1 class="govuk-heading-l">Upload your {{ data['qualificationInstitutionName'] }} teaching qualification transcript</h1>
+        <p>Upload a transcript of your teaching qualification, issued by the awarding body. If your teaching qualification was completed as part of your degree, you should supply your degree transcript.</p>
         <h2 class="govuk-heading-m">Upload your transcript</h2>
         <div class="govuk-form-group">
           <label class="govuk-label" for="file-upload-1">
@@ -68,7 +68,7 @@
               <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-written-in-english-2">
                 <div class="govuk-form-group">
                   <label class="govuk-label" for="file-upload-2">
-                    Upload your qualification certificate translation
+                    Upload your teaching qualification transcript translation
                   </label>
                   <div id="event-name-hint" class="govuk-hint">
                     Select a file to upload

--- a/app/views/prototype-3/qualifications/teacher-training-qualification/teacher-training-qualification-summary.html
+++ b/app/views/prototype-3/qualifications/teacher-training-qualification/teacher-training-qualification-summary.html
@@ -13,7 +13,7 @@
     <div class="govuk-grid-column-two-thirds-from-desktop">
 
       <span class="govuk-caption-l">
-        Teacher training and qualifications
+        Your qualifications
       </span>
 
       <h1 class="govuk-heading-xl">Check your answers</h1>

--- a/app/views/prototype-3/qualifications/teacher-training-qualification/teacher-training-qualification.html
+++ b/app/views/prototype-3/qualifications/teacher-training-qualification/teacher-training-qualification.html
@@ -29,11 +29,11 @@
     <div class="govuk-grid-column-two-thirds">
       <span class="govuk-caption-l">Your qualifications</span>
       <h1 class="govuk-heading-l">Your teaching qualification</h1>
-      <p class="govuk-body-l">This is the qualification that led to you being recognised as a teacher. It might be part of your university degree course, or it could be a separate qualification. You can tell us about additional qualifications later if you want to.</p>
+      <p class="govuk-body">This is the qualification that led to you being recognised as a teacher. It might be part of your university degree course, or it could be a separate qualification.</p>
 
       <form class="form" action="../teacher-training-qualification-documents/upload-teacher-training-qualification" method="post">
 
-        <h2 class="govuk-heading-m">Enter the details of your teacher training qualification</h2>
+        <h2 class="govuk-heading-m">Enter the details of your teaching qualification</h2>
 
         <div class="govuk-form-group">
           <label class="govuk-label" for="qualification-title">
@@ -63,13 +63,24 @@
         items: countries
         }) }}
 
-        <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+        <details class="govuk-details" data-module="govuk-details">
+          <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">
+              Is this the same as my university degree?
+            </span>
+          </summary>
+          <div class="govuk-details__text">
+            <p class="govuk-body">Some applicants have a university degree qualification that includes their teaching qualification.</p>
+            <p class="govuk-body">Others have a teaching qualification that’s separate from their degree.</p>
+            <p class="govuk-body">If your qualifications are separate, you’ll need to add your university degree in the next section.</p>
+          </div>
+        </details>
 
         <div class="govuk-form-group">
           <fieldset class="govuk-fieldset" role="group" aria-describedby="start-date-hint">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
               <h1 class="govuk-fieldset__heading">
-                When did you start your teacher training qualification?
+                When did you start your teaching qualification?
               </h1>
             </legend>
             <div id="start-date-hint" class="govuk-hint">
@@ -100,7 +111,7 @@
           <fieldset class="govuk-fieldset" role="group" aria-describedby="qualification-end-date-date-hint">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
               <h1 class="govuk-fieldset__heading">
-                When did you complete your teacher training qualification?
+                When did you complete your teaching qualification?
               </h1>
             </legend>
             <div id="start-date-hint" class="govuk-hint">
@@ -131,7 +142,7 @@
           <fieldset class="govuk-fieldset" role="group" aria-describedby="qualificationAwardDate-hint">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
               <h1 class="govuk-fieldset__heading">
-                What is the date on your teacher training qualification certificate?
+                What is the date on your teaching qualification certificate?
               </h1>
             </legend>
             <div id="start-date-hint" class="govuk-hint">


### PR DESCRIPTION
Removed references to ‘Training’ as user found it confusing and various other content tweaks.

Signed-off-by: Andrew Scrivener <andrew.scrivener@digital.homeoffice.gov.uk>